### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.2+17] - June 6, 2023
+
+* Automated dependency updates
+
+
 ## [3.0.2+16] - May 30, 2023
 
 * Automated dependency updates
@@ -251,6 +256,7 @@
 ## [1.0.0+1] - November 15th, 2021
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_rive'
 description: 'A plugin to the JSON Dynamic Widget to provide Rive support to the widgets'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_rive'
-version: '3.0.2+16'
+version: '3.0.2+17'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -17,10 +17,10 @@ dependencies:
     sdk: 'flutter'
   json_class: '^2.2.1+3'
   json_dynamic_widget: '^6.0.5+3'
-  json_theme: '^5.0.2+6'
+  json_theme: '^6.0.0'
   logging: '^1.2.0'
   meta: '^1.8.0'
-  rive: '^0.11.1'
+  rive: '^0.11.2'
   uuid: '^3.0.7'
 
 false_secrets: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_theme`: 5.0.2+6 --> 6.0.0
  * `rive`: 0.11.1 --> 0.11.2


Error!!!
```
Resolving dependencies...
  _fe_analyzer_shared 58.0.0 (61.0.0 available)
  analyzer 5.10.0 (5.13.0 available)
  archive 3.3.2 (3.3.7 available)
  args 2.4.0 (2.4.2 available)
  async 2.11.0
  boolean_selector 2.1.1
  browser_launcher 1.1.1
  built_collection 5.1.1
  built_value 8.4.4 (8.6.1 available)
  checked_yaml 2.0.2 (2.0.3 available)
  clock 1.1.1
  collection 1.17.1 (1.17.2 available)
  completion 1.0.1
  convert 3.1.1
  coverage 1.6.3
  crypto 3.0.2 (3.0.3 available)
  csslib 0.17.2 (0.17.3 available)
  dds 2.7.10 (2.8.3 available)
  dds_service_extensions 1.3.3 (1.4.0 available)
  devtools_shared 2.23.0 (2.24.0 available)
  dwds 19.0.0
  fake_async 1.3.1
  file 6.1.4 (7.0.0 available)
  file_testing 3.0.0
  fixnum 1.1.0
  flutter_template_images 4.2.0
  frontend_server_client 3.2.0
  glob 2.1.1 (2.1.2 available)
  html 0.15.2 (0.15.3 available)
  http 0.13.5 (1.0.0 available)
  http_multi_server 3.2.1
  http_parser 4.0.2
  intl 0.18.0 (0.18.1 available)
  io 1.0.4
  js 0.6.7
  json_annotation 4.8.0 (4.8.1 available)
  json_rpc_2 3.0.2
  logging 1.1.1 (1.2.0 available)
  matcher 0.12.15 (0.12.16 available)
  meta 1.9.1
  mime 1.0.4
  multicast_dns 0.3.2+3
  mustache_template 2.0.0
  native_stack_traces 0.5.5
  node_preamble 2.0.2
  package_config 2.1.0
  path 1.8.3
  petitparser 5.3.0 (5.4.0 available)
  platform 3.1.0
  pool 1.5.1
  process 4.2.4
  pub_semver 2.1.3 (2.1.4 available)
  pubspec_parse 1.2.2 (1.2.3 available)
  shelf 1.4.0 (1.4.1 available)
  shelf_packages_handler 3.0.1 (3.0.2 available)
  shelf_proxy 1.0.2 (1.0.4 available)
  shelf_static 1.1.1 (1.1.2 available)
  shelf_web_socket 1.0.3 (1.0.4 available)
  source_map_stack_trace 2.1.1
  source_maps 0.10.12
  source_span 1.9.1 (1.10.0 available)
  sse 4.1.2
  stack_trace 1.11.0
  standard_message_codec 0.0.1+3
  stream_channel 2.1.1
  string_scanner 1.2.0
  sync_http 0.3.1
  term_glyph 1.2.1
  test 1.24.1 (1.24.3 available)
  test_api 0.5.1 (0.6.0 available)
  test_core 0.5.1 (0.5.3 available)
  typed_data 1.3.1 (1.3.2 available)
  unified_analytics 1.1.0 (2.0.0 available)
  usage 4.1.0 (4.1.1 available)
  uuid 3.0.7
  vm_service 11.3.0 (11.6.0 available)
  vm_snapshot_analysis 0.7.2
  watcher 1.0.2 (1.1.0 available)
  web_socket_channel 2.3.0 (2.4.0 available)
  webdriver 3.0.2
  webkit_inspection_protocol 1.2.0
  xml 6.2.2 (6.3.0 available)
  yaml 3.1.1 (3.1.2 available)
No dependencies changed.
40 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
Resolving dependencies...


Building flutter tool...
Because json_dynamic_widget_plugin_rive depends on json_dynamic_widget ^6.0.5+3 which depends on json_theme ^5.0.2+6, json_theme ^5.0.2+6 is required.
So, because json_dynamic_widget_plugin_rive depends on json_theme ^6.0.0, version solving failed.

```


