### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+5] - December 26, 2023
+
+* Automated dependency updates
+
+
 ## [4.0.0+4] - October 10, 2023
 
 * Automated dependency updates
@@ -331,6 +336,7 @@
 ## [1.0.0+1] - November 15th, 2021
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+2'
+version: '1.0.0+3'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -9,7 +9,7 @@ environment:
 dependencies: 
   flutter: 
     sdk: 'flutter'
-  json_dynamic_widget: '^7.0.2'
+  json_dynamic_widget: '^7.0.6+3'
   json_dynamic_widget_plugin_rive: 
     path: '../'
   logging: '^1.2.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_rive'
 description: 'A plugin to the JSON Dynamic Widget to provide Rive support to the widgets'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_rive'
-version: '4.0.0+4'
+version: '4.0.0+5'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -12,26 +12,26 @@ analyzer:
 
 
 dependencies: 
-  child_builder: '^2.0.1'
+  child_builder: '^2.0.2'
   flutter: 
     sdk: 'flutter'
-  json_class: '^3.0.0+5'
-  json_dynamic_widget: '^7.0.2'
-  json_theme: '^6.3.0'
+  json_class: '^3.0.0+10'
+  json_dynamic_widget: '^7.0.6+3'
+  json_theme: '^6.4.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  rive: '^0.11.17'
-  uuid: '^4.1.0'
+  rive: '^0.12.4'
+  uuid: '^4.3.1'
 
 false_secrets: 
   - 'example/web/index.html'
 
 dev_dependencies: 
-  build_runner: '^2.4.6'
-  flutter_lints: '^2.0.3'
+  build_runner: '^2.4.7'
+  flutter_lints: '^3.0.1'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.1+1'
+  json_dynamic_widget_codegen: '^1.0.4+5'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `child_builder`: 2.0.1 --> 2.0.2
  * `json_class`: 3.0.0+5 --> 3.0.0+10
  * `json_dynamic_widget`: 7.0.2 --> 7.0.6+3
  * `json_theme`: 6.3.0 --> 6.4.0
  * `rive`: 0.11.17 --> 0.12.4
  * `uuid`: 4.1.0 --> 4.3.1

dev_dependencies:
  * `build_runner`: 2.4.6 --> 2.4.7
  * `flutter_lints`: 2.0.3 --> 3.0.1
  * `json_dynamic_widget_codegen`: 1.0.1+1 --> 1.0.4+5


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use 'flutter config --no-animations'.  ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-analytics.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Note: meta is pinned to version 1.10.0 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter_test from sdk depends on meta 1.10.0 and uuid >=4.3.0 depends on meta ^1.11.0, flutter_test from sdk is incompatible with uuid >=4.3.0.
So, because json_dynamic_widget_plugin_rive depends on both uuid ^4.3.1 and flutter_test from sdk, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on uuid: flutter pub add uuid:^4.2.2

```


dependencies:
  * `json_dynamic_widget`: 7.0.2 --> 7.0.6+3


Error!!!
```
Resolving dependencies...


Note: meta is pinned to version 1.10.0 by flutter from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter from sdk depends on meta 1.10.0 and uuid >=4.3.0 depends on meta ^1.11.0, flutter from sdk is incompatible with uuid >=4.3.0.
And because every version of json_dynamic_widget_plugin_rive from path depends on uuid ^4.3.1, flutter from sdk is incompatible with json_dynamic_widget_plugin_rive from path.
So, because example depends on both flutter from sdk and json_dynamic_widget_plugin_rive from path, version solving failed.

```

