### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+22] - February 11, 2025
+
+* Automated dependency updates
+
+
 ## [4.0.0+21] - December 10, 2024
 
 * Automated dependency updates

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+17'
+version: '1.0.0+18'
 
 environment:
   sdk: '>=2.19.0 <4.0.0'
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: 'flutter'
-  json_dynamic_widget: '^7.3.1+13'
+  json_dynamic_widget: '^8.0.0+1'
   json_dynamic_widget_plugin_rive:
     path: '../'
   logging: '^1.3.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_rive'
 description: 'A plugin to the JSON Dynamic Widget to provide Rive support to the widgets'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_rive'
-version: '4.0.0+21'
+version: '4.0.0+22'
 
 environment:
   sdk: '>=2.19.0 <4.0.0'
@@ -15,8 +15,8 @@ dependencies:
   flutter:
     sdk: 'flutter'
   json_class: '^3.0.1'
-  json_dynamic_widget: '^7.3.1+13'
-  json_theme: '^6.5.4+1'
+  json_dynamic_widget: '^8.0.0+1'
+  json_theme: '^7.0.0+3'
   logging: '^1.3.0'
   meta: '^1.12.0'
   rive: '^0.13.20'
@@ -26,11 +26,11 @@ false_secrets:
   - 'example/web/index.html'
 
 dev_dependencies:
-  build_runner: '^2.4.13'
+  build_runner: '^2.4.14'
   flutter_lints: '^5.0.0'
   flutter_test:
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.6+18'
+  json_dynamic_widget_codegen: '^2.0.0+2'
 
 permittedLicenses:
   - 'Apache-2.0'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_dynamic_widget`: 7.3.1+13 --> 8.0.0+1
  * `json_theme`: 6.5.4+1 --> 7.0.0+3

dev_dependencies:
  * `build_runner`: 2.4.13 --> 2.4.14
  * `json_dynamic_widget_codegen`: 1.0.6+18 --> 2.0.0+2


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/to/crash-reporting                                     ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use                                    ║
  ║ 'flutter config --no-cli-animations'.                                      ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
Downloading packages...
+ _fe_analyzer_shared 76.0.0 (80.0.0 available)
+ _macros 0.3.3 from sdk dart
+ analyzer 6.11.0 (7.3.0 available)
+ args 2.6.0
+ asn1lib 1.5.9
+ async 2.11.0 (2.13.0 available)
+ boolean_selector 2.1.1 (2.1.2 available)
+ build 2.4.2
+ build_config 1.1.2
+ build_daemon 4.0.3
+ build_resolvers 2.4.3
+ build_runner 2.4.14
+ build_runner_core 8.0.0
+ built_collection 5.1.1
+ built_value 8.9.3
+ characters 1.3.0 (1.4.0 available)
+ checked_yaml 2.0.3
+ child_builder 2.0.2
+ clock 1.1.1 (1.1.2 available)
+ code_builder 4.10.1
+ collection 1.19.0 (1.19.1 available)
+ convert 3.1.2
+ crypto 3.0.6
+ dart_style 3.0.1
+ dynamic_widget_annotation 2.0.0
+ encrypt 5.0.3
+ execution_timer 1.1.0+13
+ fake_async 1.3.1 (1.3.3 available)
+ ffi 2.1.3
+ file 7.0.1
+ fixnum 1.1.1
+ flutter 0.0.0 from sdk flutter
+ flutter_lints 5.0.0
+ flutter_test 0.0.0 from sdk flutter
+ flutter_web_plugins 0.0.0 from sdk flutter
+ form_validation 3.2.0
+ frontend_server_client 4.0.0
+ glob 2.1.3
+ graphs 2.3.2
+ http 1.3.0
+ http_multi_server 3.2.2
+ http_parser 4.1.2
+ interpolation 2.1.2
+ intl 0.20.2
+ io 1.0.5
+ iregexp 0.1.2
+ js 0.7.1
+ json_annotation 4.9.0
+ json_class 3.0.1
+ json_conditional 3.0.1+17
+ json_dynamic_widget 8.0.0+1
+ json_dynamic_widget_codegen 2.0.0+2
+ json_path 0.7.5
+ json_schema 5.2.0
+ json_theme 7.0.0+3
+ json_theme_annotation 1.0.3+15
+ leak_tracker 10.0.7 (10.0.9 available)
+ leak_tracker_flutter_testing 3.0.8 (3.0.9 available)
+ leak_tracker_testing 3.0.1
+ lints 5.1.1
+ logging 1.3.0
+ macros 0.1.3-main.0
+ matcher 0.12.16+1 (0.12.17 available)
+ material_color_utilities 0.11.1 (0.12.0 available)
+ maybe_just_nothing 0.5.3
+ meta 1.15.0 (1.16.0 available)
+ mime 2.0.0
+ package_config 2.1.1
+ path 1.9.0 (1.9.1 available)
+ petitparser 6.0.2 (6.1.0 available)
+ plugin_platform_interface 2.1.8
+ pointycastle 3.9.1
+ pool 1.5.1
+ pub_semver 2.1.5
+ pubspec_parse 1.5.0
+ quiver 3.2.2
+ recase 4.1.0
+ rfc_6901 0.2.0
+ rive 0.13.20
+ rive_common 0.4.15
+ rxdart 0.28.0
+ shelf 1.4.2
+ shelf_web_socket 2.0.1 (3.0.0 available)
+ sky_engine 0.0.0 from sdk flutter
+ source_gen 2.0.0
+ source_span 1.10.0 (1.10.1 available)
+ sprintf 7.0.0
+ stack_trace 1.12.0 (1.12.1 available)
+ stream_channel 2.1.2 (2.1.4 available)
+ stream_transform 2.1.1
+ string_scanner 1.3.0 (1.4.1 available)
+ template_expressions 3.3.1+2
+ term_glyph 1.2.1 (1.2.2 available)
+ test_api 0.7.3 (0.7.4 available)
+ timing 1.0.2
+ typed_data 1.4.0
+ uri 1.0.0
+ uuid 4.5.1
+ vector_math 2.1.4
+ vm_service 14.3.0 (15.0.0 available)
+ watcher 1.1.1
+ web 1.1.0
+ web_socket 0.1.6
+ web_socket_channel 3.0.2
+ yaml 3.1.3
+ yaml_writer 2.0.1
+ yaon 1.1.4+10
Changed 107 dependencies!
23 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Resolving dependencies in `./example`...


Because every version of json_dynamic_widget_plugin_rive from path depends on json_dynamic_widget ^8.0.0+1 and example depends on json_dynamic_widget ^7.3.1+13, json_dynamic_widget_plugin_rive from path is forbidden.
So, because example depends on json_dynamic_widget_plugin_rive from path, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Try upgrading your constraint on json_dynamic_widget: flutter pub add json_dynamic_widget:'^8.0.0+1'
Failed to update packages.

```


dependencies:
  * `json_dynamic_widget`: 7.3.1+13 --> 8.0.0+1


Analysis Successful

