### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.1+7] - June 10, 2025
+
+* Automated dependency updates
+
+
 ## [4.0.1+6] - May 20, 2025
 
 * Automated dependency updates

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: "example"
 description: "Example app for the JsonDynamicWidget library"
 publish_to: "none"
-version: "1.0.0+23"
+version: "1.0.0+24"
 
 environment:
   sdk: ">=2.19.0 <4.0.0"
@@ -15,7 +15,7 @@ dependencies:
   logging: "^1.3.0"
 
 dev_dependencies:
-  flutter_lints: "^5.0.0"
+  flutter_lints: "^6.0.0"
   flutter_test:
     sdk: "flutter"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: "json_dynamic_widget_plugin_rive"
 description: "A plugin to the JSON Dynamic Widget to provide Rive support to the widgets"
 homepage: "https://github.com/peiffer-innovations/json_dynamic_widget_plugin_rive"
-version: "4.0.1+6"
+version: "4.0.1+7"
 
 environment:
   sdk: ">=3.7.0 <4.0.0"
@@ -16,7 +16,7 @@ dependencies:
     sdk: "flutter"
   json_class: "^3.0.1"
   json_dynamic_widget: "^9.0.0+7"
-  json_theme: "^8.0.0+3"
+  json_theme: "^9.0.0+2"
   logging: "^1.3.0"
   meta: "^1.12.0"
   rive: "^0.13.20"
@@ -27,7 +27,7 @@ false_secrets:
 
 dev_dependencies:
   build_runner: "^2.4.15"
-  flutter_lints: "^5.0.0"
+  flutter_lints: "^6.0.0"
   flutter_test:
     sdk: "flutter"
   json_dynamic_widget_codegen: "^2.2.0"


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_theme`: 8.0.0+3 --> 9.0.0+2

dev_dependencies:
  * `flutter_lints`: 5.0.0 --> 6.0.0


Error!!!
```
Resolving dependencies...


Because json_dynamic_widget_codegen >=2.1.0+3 depends on json_theme ^8.0.0+2 and json_dynamic_widget_plugin_rive depends on json_theme ^9.0.0+2, json_dynamic_widget_codegen >=2.1.0+3 is forbidden.
So, because json_dynamic_widget_plugin_rive depends on json_dynamic_widget_codegen ^2.2.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on json_theme: flutter pub add json_theme:'^8.0.0+3'
Failed to update packages.

```


dev_dependencies:
  * `flutter_lints`: 5.0.0 --> 6.0.0


Error!!!
```
Resolving dependencies...


Because every version of json_dynamic_widget_plugin_rive from path depends on json_theme ^9.0.0+2 and json_dynamic_widget >=9.0.0+5 depends on json_theme ^8.0.0+2, json_dynamic_widget_plugin_rive from path is incompatible with json_dynamic_widget >=9.0.0+5.
So, because example depends on both json_dynamic_widget ^9.0.0+7 and json_dynamic_widget_plugin_rive from path, version solving failed.
Failed to update packages.

```

